### PR TITLE
Deferred should not be final

### DIFF
--- a/src/Deferred.java
+++ b/src/Deferred.java
@@ -424,7 +424,7 @@ import org.slf4j.LoggerFactory;
  * </ul>
  * @param <T> The type of the deferred result.
  */
-public final class Deferred<T> {
+public class Deferred<T> {
 
   // I apologize in advance for all the @SuppressWarnings("unchecked") in this
   // class.  I feel like I'm cheating the type system but, to be honest, Java's


### PR DESCRIPTION
We use the Async Kudu Client (and I have used the Async HBase client before), and we have issues testing this in unit tests because the Deferred class is final. To mock it, we have to jump through hoops with power mock. I don't see a reason for this class to be final, so just removing the final keyword.