### PR TITLE
Use static slf4j version in published poms

### DIFF
--- a/pom.xml.in
+++ b/pom.xml.in
@@ -115,7 +115,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>[@SLF4J_API_VERSION@,)</version>
+      <version>@SLF4J_API_VERSION@</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Maven version ranges in published poms can result in less repeatable builds since the transitive dependency can change as newer versions are published. This changes the versions range to be a static version.